### PR TITLE
Inline shadow deps

### DIFF
--- a/config/bili.config.js
+++ b/config/bili.config.js
@@ -25,6 +25,7 @@ const visualizer = {
 /** @type {import('bili').Config} */
 module.exports = {
   input: { [filename]: sourceDir },
+  bundleNodeModules: ['style-inject', 'vue-runtime-helpers'],
   plugins: {
     'node-builtins': true,
     vue: true,


### PR DESCRIPTION
This PR ensures that shadow dependencies ([`style-inject`](https://npm.im/style-inject) and [`vue-runtime-helpers`](https://npm.im/vue-runtime-helpers)) are inlined inside resulting bundle. This addresses #39 