### PR TITLE
Swap `.npmignore` with `files` field

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,0 @@
-.vscode
-.DS_Store
-.editorconfig
-.git*
-.npmignore
-.eslintrc*
-.babelrc*
-examples

--- a/package.json
+++ b/package.json
@@ -2,39 +2,43 @@
   "name": "tailor-teaching-elements",
   "version": "1.4.0",
   "description": "Tailor teaching elements",
-  "main": "dist/tailor-teaching-elements.umd.min.js",
-  "module": "dist/tailor-teaching-elements.esm.js",
-  "scripts": {
-    "dev": "poi --serve",
-    "clean": "rimraf dist",
-    "lint:js": "eslint --ext .js,.vue .",
-    "lint:scss": "stylelint \"src/**/*.vue\" \"src/**/*.scss\"",
-    "lint": "npm run lint:js; npm run lint:scss",
-    "prebuild": "npm run clean",
-    "build": "bili",
-    "prepublishOnly": "npm run build",
-    "release": "np --any-branch --no-cleanup"
+  "keywords": [
+    "content-authoring",
+    "learning",
+    "tailor",
+    "teaching-elements",
+    "vue"
+  ],
+  "bugs": {
+    "url": "https://github.com/ExtensionEngine/tailor-teaching-elements/issues"
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ExtensionEngine/tailor-teaching-elements.git"
   },
-  "bugs": {
-    "url": "https://github.com/ExtensionEngine/tailor-teaching-elements/issues"
-  },
-  "keywords": [
-    "vue",
-    "tailor",
-    "teaching-elements",
-    "content-authoring",
-    "learning"
-  ],
+  "license": "MIT",
   "author": {
     "name": "ExtensionEngine",
     "email": "info@extensionengine.com",
     "url": "https://github.com/ExtensionEngine"
   },
-  "license": "MIT",
+  "files": [
+    "src",
+    "dist"
+  ],
+  "main": "dist/tailor-teaching-elements.umd.min.js",
+  "module": "dist/tailor-teaching-elements.esm.js",
+  "scripts": {
+    "prebuild": "npm run clean",
+    "build": "bili",
+    "clean": "rimraf dist",
+    "dev": "poi --serve",
+    "lint": "npm run lint:js; npm run lint:scss",
+    "lint:js": "eslint --ext .js,.vue .",
+    "lint:scss": "stylelint \"src/**/*.vue\" \"src/**/*.scss\"",
+    "prepublishOnly": "npm run build",
+    "release": "np --any-branch --no-cleanup"
+  },
   "config": {
     "moduleName": "TailorTeachingElements"
   },
@@ -42,15 +46,11 @@
     "last 2 versions",
     "ie 11"
   ],
-  "peerDependencies": {
-    "vue": "^2.5.x",
-    "@mdi/font": "^3.0.39"
-  },
   "dependencies": {
+    "jodit": "^3.2.55",
     "lodash": "^4.17.15",
     "plyrue": "^2.1.4",
     "quill": "^1.3.7",
-    "jodit": "^3.2.55",
     "sass-web-fonts": "^2.1.0",
     "url-join": "^4.0.1",
     "video.js": "^7.6.5",
@@ -96,6 +96,10 @@
     "to-title-case": "^1.0.0",
     "vue": "^2.5.0",
     "vue-template-compiler": "2.6.10"
+  },
+  "peerDependencies": {
+    "@mdi/font": "^3.0.39",
+    "vue": "^2.5.x"
   },
   "engines": {
     "node": ">=8.5.0",


### PR DESCRIPTION
This PR swaps `.npmignore` with `files` field inside `package.json`. Additionally `package.json` fields have been sorted using `sort-package-json`.

(as suggested here: https://github.com/ExtensionEngine/tailor-teaching-elements/pull/38#issuecomment-539875224)