### PR TITLE
Allow passing options to accordion element

### DIFF
--- a/src/teaching-element/Accordion/Item.vue
+++ b/src/teaching-element/Accordion/Item.vue
@@ -24,7 +24,7 @@
 import Primitive from '../Primitive.vue';
 import VueScrollTo from 'vue-scrollto';
 
-const options = {
+const DEFAULT_OPTIONS = {
   container: 'body',
   easing: 'ease',
   cancelable: true,
@@ -37,7 +37,8 @@ export default {
   name: 'te-accordion-item',
   props: {
     elements: { type: Array, required: true },
-    heading: { type: String, required: true }
+    heading: { type: String, required: true },
+    options: { type: Object, default: () => ({}) }
   },
   data() {
     return { expanded: false };
@@ -48,6 +49,7 @@ export default {
       if (this.expanded) this.scroll();
     },
     scroll() {
+      const options = Object.assign({}, DEFAULT_OPTIONS, this.options);
       VueScrollTo.scrollTo(this.$el, 500, options);
     }
   },

--- a/src/teaching-element/Accordion/index.vue
+++ b/src/teaching-element/Accordion/index.vue
@@ -3,6 +3,7 @@
     <accordion-item
       v-for="item in embeddedItems"
       :key="item.id"
+      :options="options"
       v-bind="item" />
   </ul>
 </template>
@@ -14,6 +15,9 @@ import embedHost from '@/mixin/embedHost';
 export default {
   name: 'te-accordion',
   mixins: [embedHost],
+  props: {
+    options: { type: Object, default: () => ({}) }
+  },
   components: { AccordionItem }
 };
 </script>

--- a/src/teaching-element/Accordion/index.vue
+++ b/src/teaching-element/Accordion/index.vue
@@ -3,7 +3,7 @@
     <accordion-item
       v-for="item in embeddedItems"
       :key="item.id"
-      :options="options"
+      :options="itemOptions"
       v-bind="item" />
   </ul>
 </template>
@@ -11,12 +11,18 @@
 <script>
 import AccordionItem from './Item.vue';
 import embedHost from '@/mixin/embedHost';
+import get from 'lodash/get';
 
 export default {
   name: 'te-accordion',
   mixins: [embedHost],
   props: {
     options: { type: Object, default: () => ({}) }
+  },
+  computed: {
+    itemOptions() {
+      return get(this.options, 'accordion.item');
+    }
   },
   components: { AccordionItem }
 };


### PR DESCRIPTION
For the CGMA project we require the accordion to show the title/header when expanded, which I suppose not everyone using this requires, so I've added the custom `options` prop to allow accordion customizations.