### PR TITLE
Group accordion item scroll options

### DIFF
--- a/src/teaching-element/Accordion/Item.vue
+++ b/src/teaching-element/Accordion/Item.vue
@@ -24,7 +24,7 @@
 import Primitive from '../Primitive.vue';
 import VueScrollTo from 'vue-scrollto';
 
-const DEFAULT_OPTIONS = {
+const DEFAULT_SCROLL_OPTIONS = {
   container: 'body',
   easing: 'ease',
   cancelable: true,
@@ -49,7 +49,7 @@ export default {
       if (this.expanded) this.scroll();
     },
     scroll() {
-      const options = Object.assign({}, DEFAULT_OPTIONS, this.options);
+      const options = Object.assign({}, DEFAULT_SCROLL_OPTIONS, this.options.scroll);
       VueScrollTo.scrollTo(this.$el, 500, options);
     }
   },


### PR DESCRIPTION
First level accordion item options properties should be properties
regarding the accordion item component. Options regarding the
competency's scroll behavior should be grouped under the `scroll`
options property.

Regarding https://github.com/ExtensionEngine/tailor-teaching-elements/pull/67#issuecomment-561870479
