### PR TITLE
Inline `rollup-plugin-vue` runtime dependencies

### DIFF
--- a/bili.config.js
+++ b/bili.config.js
@@ -13,7 +13,11 @@ module.exports = {
     moduleName: config.moduleName,
     extractCSS: false
   },
-  bundleNodeModules: ['style-inject', 'vue-runtime-helpers'],
+  bundleNodeModules: [
+    'rollup-plugin-vue',
+    'style-inject',
+    'vue-runtime-helpers'
+  ],
   plugins: {
     vue: true,
     babel: {


### PR DESCRIPTION
This PR resolves #69 by bundling runtime `rollup-plugin-vue` dependencies. :ambulance: