### PR TITLE
Fix BrightcoveVideo style removal

### DIFF
--- a/src/teaching-element/BrightcoveVideo.vue
+++ b/src/teaching-element/BrightcoveVideo.vue
@@ -71,14 +71,14 @@ export default {
       empty(this.$refs.videoWrapper);
     },
     removePlayerAssets() {
-      let { script, style, $el } = this;
+      const { script, style, $el } = this;
       if (script && $el.contains(script)) {
         $el.removeChild(script);
-        script = null;
+        this.script = null;
       }
       if (style && document.head.contains(style)) {
         document.head.removeChild(style);
-        style = null;
+        this.style = null;
       }
     },
     initPlayer(playerUrl = this.playerUrl) {

--- a/src/teaching-element/BrightcoveVideo.vue
+++ b/src/teaching-element/BrightcoveVideo.vue
@@ -66,12 +66,20 @@ export default {
       // Clear errors.
       this.error = null;
       // Remove player assets.
-      if (this.script) this.$el.removeChild(this.script);
-      this.script = null;
-      if (this.style) document.head.removeChild(this.style);
-      this.style = null;
+      this.removePlayerAssets();
       // Wipe wrapper contents.
       empty(this.$refs.videoWrapper);
+    },
+    removePlayerAssets() {
+      let { script, style, $el } = this;
+      if (script && $el.contains(script)) {
+        $el.removeChild(script);
+        script = null;
+      }
+      if (style && document.head.contains(style)) {
+        document.head.removeChild(style);
+        style = null;
+      }
     },
     initPlayer(playerUrl = this.playerUrl) {
       // Cleanup previous instance.


### PR DESCRIPTION
When there are multiple instances of the BrightcoveVideo teaching
element with the same playerId each of them would try to remove the same
<style> DOM node which is removed by the first instance causing errors
for all the rest of them. To fix this checks are added to verify the DOM
node exists before trying to remove it.