### PR TITLE
Add TE wrapper slot proxy

### DIFF
--- a/src/teaching-element/Carousel/index.vue
+++ b/src/teaching-element/Carousel/index.vue
@@ -5,7 +5,9 @@
       :disabled="!hasPrevious"
       aria-label="Previous slide"
       class="btn btn-link btn-slide previous">
-      <span class="icon"></span>
+      <slot name="buttonPreviousIcon">
+        <span class="icon"></span>
+      </slot>
     </button>
     <ul :style="{ height: `${itemsHeight}px` }" class="carousel-items">
       <carousel-item
@@ -19,7 +21,9 @@
       :disabled="!hasNext"
       aria-label="Next slide"
       class="btn btn-link btn-slide next">
-      <span class="icon"></span>
+      <slot name="buttonNextIcon">
+        <span class="icon"></span>
+      </slot>
     </button>
     <ul class="indicators">
       <li

--- a/src/teaching-element/index.vue
+++ b/src/teaching-element/index.vue
@@ -14,7 +14,13 @@
         :type="element.data.type"
         :position="position"
         :count="count"
-        :options="options" />
+        :options="options">
+        <template v-for="(_, slot) in $slots">
+          <template :slot="slot">
+            <slot :name="slot"></slot>
+          </template>
+        </template>
+      </component>
     </div>
   </div>
 </template>


### PR DESCRIPTION
Teaching elements should have the ability to accept slotted content such
as SVG icons in places where CSS icons are supported. Here a slot proxy
is added to the teaching element wrapper which passes the slot content
to the individual teaching element slot.

This PR also contains a commit in which the Carousel TE consumes the added proxy.