### PR TITLE
Add slot for accordion header icons

### DIFF
--- a/src/teaching-element/Accordion/Item.vue
+++ b/src/teaching-element/Accordion/Item.vue
@@ -4,7 +4,9 @@
       <div class="contents">
         <span class="title">{{ heading }}</span>
       </div>
-      <span class="icon"></span>
+      <slot name="accordionHeaderIcon">
+        <span class="icon"></span>
+      </slot>
     </div>
     <transition name="slide-fade">
       <div v-show="expanded" class="accordion-body">

--- a/src/teaching-element/Accordion/index.vue
+++ b/src/teaching-element/Accordion/index.vue
@@ -4,7 +4,13 @@
       v-for="item in embeddedItems"
       :key="item.id"
       :options="itemOptions"
-      v-bind="item" />
+      v-bind="item">
+      <template v-for="(_, slot) in $slots">
+        <template :slot="slot">
+          <slot :name="slot"></slot>
+        </template>
+      </template>
+    </accordion-item>
   </ul>
 </template>
 


### PR DESCRIPTION
In order for the Accordion TE consumer to use SVG's (or other) as button
icons a slot is needed in the place of said icon.

