### PR TITLE
Add slot for assessment status icon(s)

### DIFF
--- a/src/teaching-element/Assessment/index.vue
+++ b/src/teaching-element/Assessment/index.vue
@@ -29,7 +29,9 @@
       <hint v-if="showHint" :content="hint" />
       <div class="assessment-footer clearfix">
         <div v-if="showCorrect" :class="answerStatus.type" class="answer-status">
-          <span></span>
+          <slot name="assessmentAnswerIcon">
+            <span></span>
+          </slot>
           {{ answerStatus.note }}
         </div>
         <controls


### PR DESCRIPTION
In order for the Assessment TE consumer to use SVG's (or other) as
status icons a slot is needed in the place of said icon.

Last one! I promise :smile: 