### PR TITLE
Add slot for page break icon(s)

### DIFF
--- a/src/teaching-element/PageBreak.vue
+++ b/src/teaching-element/PageBreak.vue
@@ -9,7 +9,9 @@
       {{ tooltip }}
     </div>
     <span>
-      <span class="mdi mdi-chevron-down"></span>
+      <slot name="pageBreakIcon">
+        <span class="mdi mdi-chevron-down"></span>
+      </slot>
       <span>{{ btnLabel }}</span>
     </span>
   </div>


### PR DESCRIPTION
In order for the PageBreak TE consumer to use SVG's (or other) as
status icons a slot is needed in the place of said icon.