### PR TITLE
Split accordion header icon into open/closed icons

### DIFF
--- a/src/teaching-element/Accordion/Item.vue
+++ b/src/teaching-element/Accordion/Item.vue
@@ -4,10 +4,10 @@
       <div class="contents">
         <span class="title">{{ heading }}</span>
       </div>
-      <slot v-if="!expanded" name="accordionHeaderClosedIcon">
+      <slot v-show="!expanded" name="accordionHeaderClosedIcon">
         <span class="closed-icon"></span>
       </slot>
-      <slot v-if="expanded" name="accordionHeaderOpenIcon">
+      <slot v-show="expanded" name="accordionHeaderOpenIcon">
         <span class="open-icon"></span>
       </slot>
     </div>

--- a/src/teaching-element/Accordion/Item.vue
+++ b/src/teaching-element/Accordion/Item.vue
@@ -4,8 +4,11 @@
       <div class="contents">
         <span class="title">{{ heading }}</span>
       </div>
-      <slot name="accordionHeaderIcon">
-        <span class="icon"></span>
+      <slot v-if="!expanded" name="accordionHeaderClosedIcon">
+        <span class="closed-icon"></span>
+      </slot>
+      <slot v-if="expanded" name="accordionHeaderOpenIcon">
+        <span class="open-icon"></span>
       </slot>
     </div>
     <transition name="slide-fade">


### PR DESCRIPTION
Tracking of which icon should be displayed in the accordion item header
should be done in the accordion TE instead of its consumers.

@abasic not sure if anyone else is using this TE, but this change will be a breaking change.