### PR TITLE
Add video captions support

### DIFF
--- a/src/teaching-element/Video.vue
+++ b/src/teaching-element/Video.vue
@@ -1,8 +1,16 @@
 <template>
   <div class="te-video">
     <plyrue :options="options">
-      <video v-if="video.native">
+      <video v-if="video.native" crossorigin>
         <source :src="video.url" :type="video.mime">
+        <track
+          v-for="caption in captions"
+          :key="caption.srclang"
+          :label="caption.label"
+          :srclang="caption.srclang"
+          :src="caption.src"
+          :default="caption.default"
+          kind="captions">
       </video>
       <div v-else class="plyr__video-embed">
         <iframe :src="url" allowfullscreen></iframe>
@@ -32,6 +40,7 @@ const defaultPlayerOptions = {
     'play',
     'progress',
     'volume',
+    'captions',
     'settings',
     'fullscreen'
   ]
@@ -41,7 +50,8 @@ export default {
   name: 'te-video',
   props: {
     url: { type: String, required: true },
-    playerOptions: { type: Object, default: () => defaultPlayerOptions }
+    playerOptions: { type: Object, default: () => defaultPlayerOptions },
+    captions: { type: Array, default: () => ([]) }
   },
   computed: {
     video: ({ url }) => {

--- a/src/teaching-element/Video.vue
+++ b/src/teaching-element/Video.vue
@@ -6,10 +6,7 @@
         <track
           v-for="caption in captions"
           :key="caption.srclang"
-          :label="caption.label"
-          :srclang="caption.srclang"
-          :src="caption.src"
-          :default="caption.default"
+          v-bind="caption"
           kind="captions">
       </video>
       <div v-else class="plyr__video-embed">
@@ -51,7 +48,7 @@ export default {
   props: {
     url: { type: String, required: true },
     playerOptions: { type: Object, default: () => defaultPlayerOptions },
-    captions: { type: Array, default: () => ([]) }
+    captions: { type: Array, default: () => [] }
   },
   computed: {
     video: ({ url }) => {


### PR DESCRIPTION
This PR:
- adds `captions` prop which is then passed as is to `plyrue` to enable captions functionality
- adds `captions` to default player options `controls` array
- adds `crossorigin` property to `video` component to enable usage of TextTrack captions loaded from another domain.