### PR TITLE
Enable listening on TE Video events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11364,9 +11364,9 @@
       }
     },
     "loadjs": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-3.6.1.tgz",
-      "integrity": "sha512-AZEBw2GWdJk2IzBgQ+Wohoao5j+t0rajqK8dJu8jQqgYxDTxhmCt0ayMo/vCa0ZAMvZxnJcam6uLICfnVd8KAw=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/loadjs/-/loadjs-4.2.0.tgz",
+      "integrity": "sha512-AgQGZisAlTPbTEzrHPb6q+NYBMD+DP9uvGSIjSUM5uG+0jG15cb8axWpxuOIqrmQjn6scaaH8JwloiP27b2KXA=="
     },
     "locate-path": {
       "version": "2.0.0",
@@ -13897,30 +13897,30 @@
       }
     },
     "plyr": {
-      "version": "3.5.6",
-      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.5.6.tgz",
-      "integrity": "sha512-buudbt2qwZYjEdBXW9DvQ7t/LqaSbv9tSjCrqg7nTXVM5BXNdhuiJCyvko+5+DFMdp30mliyKGoOHGXz43OwrA==",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/plyr/-/plyr-3.5.10.tgz",
+      "integrity": "sha512-wbbSuzk3yKVOmYWQUnxG1bxikqZNkxZmL3OjS1DFVU0D2Uko1evGY72LuD9rm/HnNCNzcTuc0c6MCn7bRRpUTA==",
       "requires": {
-        "core-js": "^3.1.4",
+        "core-js": "^3.6.4",
         "custom-event-polyfill": "^1.0.7",
-        "loadjs": "^3.6.1",
+        "loadjs": "^4.2.0",
         "rangetouch": "^2.0.0",
-        "url-polyfill": "^1.1.5"
+        "url-polyfill": "^1.1.8"
       },
       "dependencies": {
         "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw=="
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+          "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         }
       }
     },
     "plyrue": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/plyrue/-/plyrue-2.1.5.tgz",
-      "integrity": "sha512-3379t1tFYczX5iVILfetakKLlnTItnyBax6TDb9w826bBFhvBsjAKqMBeGCch89gIgg2YAWoHwIFmn4RHAwauw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/plyrue/-/plyrue-2.2.0.tgz",
+      "integrity": "sha512-vySYjhhEG7xNUxdjeAHxzEXZhqaef2GWrKc/9qnTL0/ywIJ3YPai9A4AZGikuH75Za+e8EYBlxNKqhHXhAqjaA==",
       "requires": {
-        "plyr": "^3.5.6"
+        "plyr": "^3.5.10"
       }
     },
     "poi": {
@@ -17100,9 +17100,9 @@
       "dev": true
     },
     "rangetouch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rangetouch/-/rangetouch-2.0.0.tgz",
-      "integrity": "sha512-y66wTFbwh7KafYligRsmIYYR1kZY8U9tGHH9PgbVhBUFmGzPMsOSjslXPedgR5D3M9W1QKVbAf1AtaVAt7JJTw=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rangetouch/-/rangetouch-2.0.1.tgz",
+      "integrity": "sha512-sln+pNSc8NGaHoLzwNBssFSf/rSYkqeBXzX1AtJlkJiUaVSJSbRAWJk+4omsXkN+EJalzkZhWQ3th1m0FpR5xA=="
     },
     "raw-body": {
       "version": "2.4.0",
@@ -21287,9 +21287,9 @@
       }
     },
     "url-polyfill": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.7.tgz",
-      "integrity": "sha512-ZrAxYWCREjmMtL8gSbSiKKLZZticgihCvVBtrFbUVpyoETt8GQJeG2okMWA8XryDAaHMjJfhnc+rnhXRbI4DXA=="
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.8.tgz",
+      "integrity": "sha512-Ey61F4FEqhcu1vHSOMmjl0Vd/RPRLEjMj402qszD/dhMBrVfoUsnIj8KSZo2yj+eIlxJGKFdnm6ES+7UzMgZ3Q=="
     },
     "url-regex": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "hls.js": "^0.12.4",
     "jodit": "^3.2.65",
     "lodash": "^4.17.15",
-    "plyrue": "^2.1.5",
+    "plyrue": "^2.2.0",
     "quill": "^1.3.7",
     "sass-web-fonts": "^2.1.0",
     "url-join": "^4.0.1",

--- a/src/teaching-element/Video.vue
+++ b/src/teaching-element/Video.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="te-video">
-    <plyrue v-on="$listeners" :emit="activeEventListeners" :options="options">
+    <plyrue v-on="$listeners" :options="options">
       <video v-if="video.native" crossorigin>
         <source :src="video.url" :type="video.mime">
         <track
@@ -57,8 +57,7 @@ export default {
       if (isShareLink(url)) return { url: url.href, native: false };
       return { url: url.href, native: true, mime: mimetype(url) };
     },
-    options: ({ playerOptions }) => ({ ...defaultPlayerOptions, ...playerOptions }),
-    activeEventListeners: ({ $listeners }) => Object.keys($listeners)
+    options: ({ playerOptions }) => ({ ...defaultPlayerOptions, ...playerOptions })
   },
   components: { Plyrue }
 };

--- a/src/teaching-element/Video.vue
+++ b/src/teaching-element/Video.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="te-video">
-    <plyrue :options="options">
+    <plyrue v-on="$listeners" :emit="activeEventListeners" :options="options">
       <video v-if="video.native">
         <source :src="video.url" :type="video.mime">
       </video>
@@ -50,7 +50,8 @@ export default {
       if (isShareLink(url)) return { url: url.href, native: false };
       return { url: url.href, native: true, mime: mimetype(url) };
     },
-    options: ({ playerOptions }) => ({ ...defaultPlayerOptions, ...playerOptions })
+    options: ({ playerOptions }) => ({ ...defaultPlayerOptions, ...playerOptions }),
+    activeEventListeners: ({ $listeners }) => Object.keys($listeners)
   },
   components: { Plyrue }
 };


### PR DESCRIPTION
This PR enables listening to `Plyrue` events in TE `Video`.

⚠️ It's required to pass down listeners from the `teaching-element` component. This can be done with custom `teaching-element` implementation at the moment.

~We'll probably be able to drop `emit` prop in the next version of @zcuric's `Plyrue` and simply pass down event listeners to `Plyrue`.   🎉~
#### Update:
Bumped `Plyrue` to 2.2.0 and dropped emit prop (no breaking changes)