### PR TITLE
Style blank fields in JODIT's content

### DIFF
--- a/examples/data/fillBlank.json
+++ b/examples/data/fillBlank.json
@@ -25,6 +25,14 @@
       "embedded": true,
       "id": "cj3cryx0c002x3k5yord8kf6lwe",
       "type": "HTML"
+    }, {
+      "data": {
+        "content": "<p>yet another @blank field in JODIT_HTML question</p>",
+        "width": 12
+      },
+      "embedded": true,
+      "id": "ckh0o64i6000038qydms55q26",
+      "type": "JODIT_HTML"
     }],
     "type": "FB",
     "width": 12

--- a/src/teaching-element/Html.vue
+++ b/src/teaching-element/Html.vue
@@ -17,20 +17,13 @@ export default {
 </script>
 
 <style lang="scss">
+@import './stylesheets/common';
+
 .te-html {
+  @extend %blank;
+
   .content {
     padding: 12px 15px;
-  }
-
-  .blank {
-    display: inline-block;
-    margin: 0 5px;
-
-    .blank-line {
-      display: inline-block;
-      width: 50px;
-      border-bottom: 1px solid black;
-    }
   }
 }
 </style>

--- a/src/teaching-element/JoditHtml.vue
+++ b/src/teaching-element/JoditHtml.vue
@@ -17,11 +17,15 @@ export default {
 </script>
 
 <style lang="scss">
+@import './stylesheets/common';
+
 $borderSize: 6px;
 $tooltipColor: #455a64;
 
 .te-jodit-html-content {
   .jodit_wysiwyg {
+    @extend %blank;
+
     overflow: visible !important;
   }
 

--- a/src/teaching-element/stylesheets/_common.scss
+++ b/src/teaching-element/stylesheets/_common.scss
@@ -1,0 +1,12 @@
+%blank {
+  .blank {
+    display: inline-block;
+    margin: 0 5px;
+
+    .blank-line {
+      display: inline-block;
+      width: 50px;
+      border-bottom: 1px solid black;
+    }
+  }
+}


### PR DESCRIPTION
This PR applies styles to "fill in the blank" placeholders within `JoditHtml` element - the same as those applied to placeholders in the `Html` component.